### PR TITLE
Package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "detects and notifies when specified font-families loaded and rendered by the browser",
   "main": "FontLoader.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I am using browserify (node in the browser), and I wanted to add your repo as a dependency in my package.json file. Your repository does not have a package.json, which afaik is required in order to install a repo as a dependency using npm (node package manager). 

So I tried to insert the values that would be applicable to your repo, tested if it works for me (it does), and wanted to offer the result as a pull request. 

It still does not work outside a browser, but at least others using browserify should be able to include your library as a dependency. 

Also, I declared that you are on version 0.0.1 because [npm is rather adamant about including a version number](https://www.npmjs.org/doc/files/package.json.html#version). Nevertheless, as long as a package.json exists, it is also possible to include a specific commit (by its sha) as a dependency, so maintaining the version number on every new commit or release is not required for npm users to still use your latest version. Or maybe npm fetches the latest version already if you have no commits tagged, I'm not sure. 

Interested? 
