### PR TITLE
Added ability to change the document context.

### DIFF
--- a/FontLoader.js
+++ b/FontLoader.js
@@ -566,7 +566,7 @@
 				
 				// Traverse tree to the top node to see if element is in the DOM tree.
 				parentNode = this._element.parentNode;
-				while (parentNode !== window.document && parentNode !== null) {
+				while (parentNode !== this._document && parentNode !== null) {
 					parentNode = parentNode.parentNode;
 				}
 				


### PR DESCRIPTION
Hello.

We plan to use this library to solve an issue with our project (https://github.com/readium/readium-shared-js/pull/179) but it needs to be able to use a different document, one inside an iframe.

This PR adds the ability to specify this other document.

Note the move of the FontLoader.testDiv into the instance space.