### PR TITLE
Add option to load and wait for different weights of the same font-family

### DIFF
--- a/FontLoader.js
+++ b/FontLoader.js
@@ -264,6 +264,11 @@
 
 			return clonedDiv;
 		},
+		_setFontStylesForNode: function(node) {
+			node.style.fontFamily = "'" + node.getAttribute("data-font-family") + "', " + FontLoader.referenceFontFamilies[node.getAttribute("data-ref-font-family-index")];
+			node.style.fontWeight = node.getAttribute("data-font-family-weight");
+			node.style.fontStyle = node.getAttribute("data-font-family-style");
+		},
 		_loadFonts: function() {
 			var i, j, clonedDiv, sizeWatcher, sizeWatchers = [];
 
@@ -312,10 +317,7 @@
 				}
 				window.setTimeout(function() {
 					for (j = 0; j < self._testContainer.childNodes.length; j++) {
-						clonedDiv = self._testContainer.childNodes[j];
-						clonedDiv.style.fontFamily = "'" + clonedDiv.getAttribute("data-font-family") + "', " + FontLoader.referenceFontFamilies[clonedDiv.getAttribute("data-ref-font-family-index")];
-						clonedDiv.style.fontWeight = clonedDiv.getAttribute("data-font-family-weight");
-						clonedDiv.style.fontStyle = clonedDiv.getAttribute("data-font-family-style");
+						self._setFontStylesForNode(self._testContainer.childNodes[j]);
 					}
 				}, 0);
 			} else if (FontLoader.useIntervalChecking) {
@@ -336,9 +338,7 @@
 					sizeWatcher.beginWatching();
 					// Apply tested font-family
 					clonedDiv = sizeWatcher.getWatchedElement();
-					clonedDiv.style.fontFamily = "'" + clonedDiv.getAttribute("data-font-family") + "', " + FontLoader.referenceFontFamilies[clonedDiv.getAttribute("data-ref-font-family-index")];
-					clonedDiv.style.fontWeight = clonedDiv.getAttribute("data-font-family-weight");
-					clonedDiv.style.fontStyle = clonedDiv.getAttribute("data-font-family-style");
+					self._setFontStylesForNode(clonedDiv);
 				}
 			}
 		},

--- a/FontLoader.js
+++ b/FontLoader.js
@@ -249,42 +249,39 @@
 
 			this._loadFonts();
 		},
+		_cloneAndAppendNode: function(fontFamily, fontFamilyIndex, referenceFontFamiliy) {
+			var clonedDiv = this._testDiv.cloneNode(true);
+			clonedDiv.setAttribute("data-font-family", fontFamily.family);
+			clonedDiv.setAttribute("data-font-family-weight", fontFamily.weight);
+			clonedDiv.setAttribute("data-font-family-style", fontFamily.style);
+			clonedDiv.setAttribute("data-ref-font-family-index", fontFamilyIndex);
+
+			if (referenceFontFamiliy) {
+				clonedDiv.style.fontFamily = referenceFontFamiliy;
+			}
+
+			this._testContainer.appendChild(clonedDiv);
+
+			return clonedDiv;
+		},
 		_loadFonts: function() {
-			var i, j, clonedDiv, sizeWatcher, sizeWatchers = [],
-				self = this;
+			var i, j, clonedDiv, sizeWatcher, sizeWatchers = [];
 
 			// Add div for each font-family
 			for (i = 0; i < this._numberOfFontFamilies; i++) {
 				this._fontsMap[this._fontFamiliesArray[i].family + this._fontFamiliesArray[i].weight + this._fontFamiliesArray[i].style] = this._fontFamiliesArray[i];
 
-				if (FontLoader.useResizeEvent) {
-					for (j = 0; j < FontLoader.referenceFontFamilies.length; j++) {
-						clonedDiv = this._testDiv.cloneNode(true);
-						clonedDiv.setAttribute("data-font-family", this._fontFamiliesArray[i].family);
-						clonedDiv.setAttribute("data-font-family-weight", this._fontFamiliesArray[i].weight);
-						clonedDiv.setAttribute("data-font-family-style", this._fontFamiliesArray[i].style);
-						clonedDiv.setAttribute("data-ref-font-family-index", String(j));
-						clonedDiv.style.fontFamily = FontLoader.referenceFontFamilies[j];
-						this._testContainer.appendChild(clonedDiv);
-					}
-				} else if (FontLoader.useIntervalChecking) {
-					for (j = 0; j < FontLoader.referenceFontFamilies.length; j++) {
-						clonedDiv = this._testDiv.cloneNode(true);
-						clonedDiv.setAttribute("data-font-family", this._fontFamiliesArray[i].family);
-						clonedDiv.setAttribute("data-font-family-weight", this._fontFamiliesArray[i].weight);
-						clonedDiv.setAttribute("data-font-family-style", this._fontFamiliesArray[i].style);
-						clonedDiv.setAttribute("data-ref-font-family-index", String(j));
-						clonedDiv.style.fontFamily = "'" + this._fontFamiliesArray[i] + "', " + FontLoader.referenceFontFamilies[j];
-						this._testContainer.appendChild(clonedDiv);
-					}
-				} else {
-					for (j = 0; j < FontLoader.referenceFontFamilies.length; j++) {
-						clonedDiv = this._testDiv.cloneNode(true);
-						clonedDiv.setAttribute("data-font-family", this._fontFamiliesArray[i].family);
-						clonedDiv.setAttribute("data-font-family-weight", this._fontFamiliesArray[i].weight);
-						clonedDiv.setAttribute("data-font-family-style", this._fontFamiliesArray[i].style);
-						clonedDiv.setAttribute("data-ref-font-family-index", String(j));
-						clonedDiv.style.fontFamily = FontLoader.referenceFontFamilies[j];
+				for (j = 0; j < FontLoader.referenceFontFamilies.length; j++) {
+					if (FontLoader.useResizeEvent) {
+						this._cloneAndAppendNode(this._fontFamiliesArray[i], String(j), FontLoader.referenceFontFamilies[j]);
+					} else if (FontLoader.useIntervalChecking) {
+						clonedDiv = this._cloneAndAppendNode(this._fontFamiliesArray[i], String(j));
+						clonedDiv.style.fontFamily = "'" + this._fontFamiliesArray[i].familiy + "', " + FontLoader.referenceFontFamilies[j];
+						clonedDiv.style.fontWeight = this._fontFamiliesArray[i].weight;
+						clonedDiv.style.fontStyle = this._fontFamiliesArray[i].style;
+					} else {
+						clonedDiv = this._cloneAndAppendNode(this._fontFamiliesArray[i], String(j), FontLoader.referenceFontFamilies[j]);
+
 						sizeWatcher = new SizeWatcher(/** @type HTMLElement */clonedDiv, {
 							container: this._testContainer,
 							delegate: this,

--- a/FontLoader.js
+++ b/FontLoader.js
@@ -431,10 +431,7 @@
 				callbackParameter = null;
 			}
 			if (this.delegate && typeof this.delegate.fontsLoaded === "function") {
-				// let the browser process the fonts, this could prevent some race-conditions
-				setTimeout(function() {
-					this.delegate.fontsLoaded(callbackParameter);
-				}.bind(this), 0);
+				this.delegate.fontsLoaded(callbackParameter);
 			}
 		},
 

--- a/FontLoader.js
+++ b/FontLoader.js
@@ -167,16 +167,24 @@
 			var processedFonts = [];
 
 			fonts.forEach(function (font) {
-				if (self._isValidFontObject(font)) {
-					processedFonts.push(font);
-				} else if (font.indexOf(':') > -1) {
-					processedFonts = processedFonts.concat(self._convertShorthandToFontObjects(font));
-				} else {
-					processedFonts.push({
-						family: font,
-						weight: 400,
-						style: 'normal'
-					});
+				if (font === null) {
+					return;
+				}
+
+				if (typeof font === 'object') {
+					if (self._isValidFontObject(font)) {
+						processedFonts.push(font);
+					}
+				} else if (typeof font === 'string') {
+					if (font.indexOf(':') > -1) {
+						processedFonts = processedFonts.concat(self._convertShorthandToFontObjects(font));
+					} else {
+						processedFonts.push({
+							family: font,
+							weight: 400,
+							style: 'normal'
+						});
+					}
 				}
 			});
 
@@ -196,8 +204,8 @@
 		_convertShorthandToFontObjects: function(fontString) {
 			var self = this;
 			var fonts = [];
-			var variants = font.split(':')[1].split(',');
-			var font = font.split(':')[0];
+			var variants = fontString.split(':')[1].split(',');
+			var font = fontString.split(':')[0];
 
 			variants.forEach(function (variant) {
 				var style = 'normal';
@@ -270,7 +278,8 @@
 			node.style.fontStyle = node.getAttribute("data-font-family-style");
 		},
 		_loadFonts: function() {
-			var i, j, clonedDiv, sizeWatcher, sizeWatchers = [];
+			var i, j, clonedDiv, sizeWatcher, sizeWatchers = [],
+				self = this;
 
 			// Add div for each font-family
 			for (i = 0; i < this._numberOfFontFamilies; i++) {
@@ -281,7 +290,7 @@
 						this._cloneAndAppendNode(this._fontFamiliesArray[i], String(j), FontLoader.referenceFontFamilies[j]);
 					} else if (FontLoader.useIntervalChecking) {
 						clonedDiv = this._cloneAndAppendNode(this._fontFamiliesArray[i], String(j));
-						clonedDiv.style.fontFamily = "'" + this._fontFamiliesArray[i].familiy + "', " + FontLoader.referenceFontFamilies[j];
+						clonedDiv.style.fontFamily = "'" + this._fontFamiliesArray[i].family + "', " + FontLoader.referenceFontFamilies[j];
 						clonedDiv.style.fontWeight = this._fontFamiliesArray[i].weight;
 						clonedDiv.style.fontStyle = this._fontFamiliesArray[i].style;
 					} else {
@@ -408,7 +417,7 @@
 			}
 			
 			if (this._numberOfLoadedFonts < this._numberOfFontFamilies) {
-				for (font in this._fontsMap) {
+				for (var font in this._fontsMap) {
 					if (this._fontsMap.hasOwnProperty(font)) {
 						notLoadedFontFamilies.push(this._fontsMap[font]);
 					}

--- a/FontLoader.js
+++ b/FontLoader.js
@@ -229,12 +229,14 @@
 
 			// Add div for each font-family
 			for (i = 0; i < this._numberOfFontFamilies; i++) {
-				this._fontsMap[this._fontFamiliesArray[i]] = true;
+				this._fontsMap[this._fontFamiliesArray[i].family + this._fontFamiliesArray[i].weight + this._fontFamiliesArray[i].style] = this._fontFamiliesArray[i];
 
 				if (FontLoader.useResizeEvent) {
 					for (j = 0; j < FontLoader.referenceFontFamilies.length; j++) {
 						clonedDiv = this._testDiv.cloneNode(true);
-						clonedDiv.setAttribute("data-font-family", this._fontFamiliesArray[i]);
+						clonedDiv.setAttribute("data-font-family", this._fontFamiliesArray[i].family);
+						clonedDiv.setAttribute("data-font-family-weight", this._fontFamiliesArray[i].weight);
+						clonedDiv.setAttribute("data-font-family-style", this._fontFamiliesArray[i].style);
 						clonedDiv.setAttribute("data-ref-font-family-index", String(j));
 						clonedDiv.style.fontFamily = FontLoader.referenceFontFamilies[j];
 						this._testContainer.appendChild(clonedDiv);
@@ -242,7 +244,9 @@
 				} else if (FontLoader.useIntervalChecking) {
 					for (j = 0; j < FontLoader.referenceFontFamilies.length; j++) {
 						clonedDiv = this._testDiv.cloneNode(true);
-						clonedDiv.setAttribute("data-font-family", this._fontFamiliesArray[i]);
+						clonedDiv.setAttribute("data-font-family", this._fontFamiliesArray[i].family);
+						clonedDiv.setAttribute("data-font-family-weight", this._fontFamiliesArray[i].weight);
+						clonedDiv.setAttribute("data-font-family-style", this._fontFamiliesArray[i].style);
 						clonedDiv.setAttribute("data-ref-font-family-index", String(j));
 						clonedDiv.style.fontFamily = "'" + this._fontFamiliesArray[i] + "', " + FontLoader.referenceFontFamilies[j];
 						this._testContainer.appendChild(clonedDiv);
@@ -250,7 +254,9 @@
 				} else {
 					for (j = 0; j < FontLoader.referenceFontFamilies.length; j++) {
 						clonedDiv = this._testDiv.cloneNode(true);
-						clonedDiv.setAttribute("data-font-family", this._fontFamiliesArray[i]);
+						clonedDiv.setAttribute("data-font-family", this._fontFamiliesArray[i].family);
+						clonedDiv.setAttribute("data-font-family-weight", this._fontFamiliesArray[i].weight);
+						clonedDiv.setAttribute("data-font-family-style", this._fontFamiliesArray[i].style);
 						clonedDiv.setAttribute("data-ref-font-family-index", String(j));
 						clonedDiv.style.fontFamily = FontLoader.referenceFontFamilies[j];
 						sizeWatcher = new SizeWatcher(/** @type HTMLElement */clonedDiv, {
@@ -285,6 +291,8 @@
 					for (j = 0; j < self._testContainer.childNodes.length; j++) {
 						clonedDiv = self._testContainer.childNodes[j];
 						clonedDiv.style.fontFamily = "'" + clonedDiv.getAttribute("data-font-family") + "', " + FontLoader.referenceFontFamilies[clonedDiv.getAttribute("data-ref-font-family-index")];
+						clonedDiv.style.fontWeight = clonedDiv.getAttribute("data-font-family-weight");
+						clonedDiv.style.fontStyle = clonedDiv.getAttribute("data-font-family-style");
 					}
 				}, 0);
 			} else if (FontLoader.useIntervalChecking) {
@@ -306,6 +314,8 @@
 					// Apply tested font-family
 					clonedDiv = sizeWatcher.getWatchedElement();
 					clonedDiv.style.fontFamily = "'" + clonedDiv.getAttribute("data-font-family") + "', " + FontLoader.referenceFontFamilies[clonedDiv.getAttribute("data-ref-font-family-index")];
+					clonedDiv.style.fontWeight = clonedDiv.getAttribute("data-font-family-weight");
+					clonedDiv.style.fontStyle = clonedDiv.getAttribute("data-font-family-style");
 				}
 			}
 		},

--- a/FontLoader.js
+++ b/FontLoader.js
@@ -697,8 +697,8 @@
 					return;
 				}
 			}
-			
-			if (!this._continuous) {
+
+			if (!this._continuous || this._delegate.isFinished()) {
 				this.endWatching();
 			} else {
 				// Set the new size so in case of double scroll event we won't cause the delegate method to be executed twice

--- a/FontLoader.js
+++ b/FontLoader.js
@@ -730,7 +730,14 @@
 			if (this._state !== SizeWatcher.states.watchingForSizeChange) {
 				return;
 			}
-			
+
+			// In some rare cases, handleEvent is called while the delegate is finished but did
+			// non clean up the DOM elements yet. In this situation we don't want the fontloader to
+			// handle this event.
+			if (this._delegate && this._delegate.isFinished()) {
+				return;
+			}
+
 			newSize = new Size(this._element.offsetWidth, this._element.offsetHeight);
 			oldSize = this._size;
 			
@@ -752,7 +759,7 @@
 				}
 			}
 
-			if (!this._continuous || this._delegate.isFinished()) {
+			if (!this._continuous) {
 				this.endWatching();
 			} else {
 				// Set the new size so in case of double scroll event we won't cause the delegate method to be executed twice

--- a/FontLoader.js
+++ b/FontLoader.js
@@ -45,12 +45,48 @@
 	 * @constructor
 	 */
 	function FontLoader(fontFamiliesArray, delegate, timeout, contextDocument) {
+		var self = this;
+
 		// Public
 		this.delegate = delegate;
 		this.timeout = (typeof timeout !== "undefined") ? timeout : 3000;
 
+		// Process font families
+		this._fontFamiliesArray = [];
+
+		fontFamiliesArray.forEach(function (font) {
+			if (font.family) {
+				self._fontFamiliesArray.push(font);
+			} else if (font.indexOf(':') > -1) {
+				var variants = font.split(':')[1].split(',');
+				font = font.split(':')[0];
+
+				variants.forEach(function (variant) {
+					var style = 'normal';
+					if (variant.charAt(0) === 'i') {
+						style = 'italic';
+					} else if (variant.charAt(0) === 'b') {
+						style = 'bold';
+					} else if (variant.charAt(0) === 'o') {
+						style = 'oblique';
+					}
+
+					self._fontFamiliesArray.push({
+						family: font,
+						weight: parseInt(variant.charAt(1)) * 100,
+						style: style
+					});
+				});
+			} else {
+				self._fontFamiliesArray.push({
+					family: font,
+					weight: 400,
+					style: 'normal'
+				});
+			}
+		});
+
 		// Private
-		this._fontFamiliesArray = fontFamiliesArray.slice(0);
 		this._testDiv = null;
 		this._testContainer = null;
 		this._adobeBlankSizeWatcher = null;


### PR DESCRIPTION
Hi guys,

For Blendle, we use your fontloader and it works really good. However, we needed the ability to load different weights. I added this to the fontloader and wanted to pass it back to you guys. This code has been running in production for over 6 months without issues.

I basically expanded the fontFamiliesArray with a set of options. There are three ways of using it:

```
new FontLoader(["MyFont", "MyOtherFont", "FontWithoutWeight"], ...);
```

In this case, a default weight of 400 and style `normal` will be used. The browser would fall back to this in a normal case as well.

- - -

```
new FontLoader(["MyFont:n4,i7", "MyOtherFont:n4"], ...);
```

This variant is using the same standard as described and used in the typekit webfontloader: https://github.com/typekit/webfontloader#custom

The first part specifies the font, after that multiple variants can be passed: `i` for italic, `o` for oblique, `b` for bold. The integer specifies the weight.

- - -

```
new FontLoader([{
    family: "MyFont",
    weight: 400,
    style: 'normal'
}, {...}], ...);
```

We also allow a font object to be passed, for easy setting up.

Please let me know what you think, any refactors necessary to meet the standard or other considerations!